### PR TITLE
Partial Evaluation Debugger

### DIFF
--- a/public/scripts/evalNode.js
+++ b/public/scripts/evalNode.js
@@ -1,7 +1,7 @@
 var m = mori;
 
-var strucureUrl = "/suite/webapi/structure";
-var traceUrl = "/suite/webapi/evaluationTrace";
+var structureUrl = "/data/ped-default/rules/SYSTEM_SYSRULES_uiSubmittableForm.structure";
+var traceUrl = "/data/ped-default/tests/SAILTest/SaveMultiple/initial.trace";
 
 var styles = {
   selected: {
@@ -121,21 +121,12 @@ var App = React.createClass({
   reevaluateExpression: function(expression) {
     console.log("calling first ajax call");
     var self = this;
-    $.ajax({
-      url: strucureUrl,
-      dataType: "json",
-      type: "GET",
-      data: {expression: expression},
-      success: function(structure) {
+    $.getJSON(structureUrl, function(structure) {
         var initialSnapshot = m.toClj(structure);
 
-        $.ajax({
-          url: traceUrl,
-          dataType: "json",
-          type: "GET",
-          data: {expression: expression},
-          success: function(trace) {
-            var events = m.toClj(trace);
+        $.getJSON(traceUrl, function(trace) {
+            console.log("trace.events: " + trace.events);
+            var events = m.toClj(trace.events);
             self.setState({
               config: initialSnapshot,
               snapshots: self.getAllSnapshots(initialSnapshot, events),
@@ -143,13 +134,8 @@ var App = React.createClass({
               currentIndex: 0,
               mode:'debugger'
             });
-          }
         });
-      },
-      error: function(err) {
-        console.log(err);
-      }
-    });
+      });
   },
   updateIndexOp: function(index) {
     this.setState({

--- a/server.js
+++ b/server.js
@@ -14,16 +14,14 @@ var fs = require('fs');
 var path = require('path');
 var express = require('express');
 var bodyParser = require('body-parser');
-var cors = require('cors')
 var app = express()
-app.use(cors())
+var serveIndex = require('serve-index')
 
 app.set('port', (process.env.PORT || 3000));
 
 
 app.use('/', express.static(path.join(__dirname, 'public')));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: true}));
+app.use('/', serveIndex('public', {'icons': false}));
 
 app.get('/comments.json', function(req, res) {
   fs.readFile('comments.json', function(err, data) {


### PR DESCRIPTION
@a2ndrade 
We realized we could just serve the data from same embedded server as the renderer client - we just needed to tweak the config somewhat so it would support directory listings (it honors the client's ACCEPT header so we can get the listing as a JSON document too). At this point, we're not familiar enough with the client implementation to be able to further debug what's broken nor continue on addressing the known changes we need to make (changes to extract relative eval paths, support rule invocation, show list of events, filter events, etc.)

CC: @anitajorgensen @marcelvaldez
